### PR TITLE
Dockerized script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.gitignore
+LICENSE
+README.md
+./vscode

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@
 # Ignore code-workspaces
 *.code-workspace
 
+env/
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+
+FROM python:slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt /app
+
+RUN ["pip", "install", "-r", "requirements.txt"]
+
+COPY ./better-call-reward.py /app
+
+CMD [ "python3", "-u", "better-call-reward.py"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Transcoders:
 [ 2022-06-02 10:33:26.292445 ] <Response [404]>
 [ 2022-06-02 10:33:26.292469 ] Call to reward fail. Error: <Response [404]>
 ```
+#### Launch using docker compose:
+1. Clone this repo and cd into it: `cd better-call-reward/`
+2. Run to launch the script `docker-compose up --build -d`
+3. Confirm that is working: `docker-compose logs -f --tail=100 script`
+
+**Note** that inside docker-compose file, the network is in host mode to be able to call localhost as the real host and not as the container. If your orchestrator is dockerized, you would need to remove this and point your Orchestrator container using the container IP or the docker compose service name.
 
 Buy me a coffee:  <br />
 LPT (Arbitrum): `0xE32971e1a55152A94Fa55DFb80ACdC4bA55679C3`  <br />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.3'
+
+services:
+  monitor: 
+    image: senseinode/scripts:livepeer-call-reward
+    network_mode: host
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ version: '3.3'
 
 services:
   monitor: 
-    image: senseinode/scripts:livepeer-call-reward
+    build: .
     network_mode: host
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 
 services:
-  monitor: 
+  script: 
     build: .
     network_mode: host
     restart: always

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2022.12.7
+charset-normalizer==2.1.1
+idna==3.4
+requests==2.28.1
+urllib3==1.26.14


### PR DESCRIPTION
## Description
This PR provides a docker image and a docker-compose file that allow you to easily launch the script.

Note that inside docker-compose file, the network is in host mode to be able to call localhost as the real host and not as the container. If your orchestrator is dockerized, you would need to remove this and point your Orchestrator container using the container IP or the docker compose service name.

### How to use
You need to have docker and docker compose installed on your server

1. Clone this repo and cd into it: `cd better-call-reward/`
2. Run to launch the script `docker-compose up --build -d`
3. Confirm that is working: `docker-compose logs -f --tail=100 script`

That's all :).

Efrain Pineda Jaimes
Blockchain Engineer at [Senseinode.com](https://senseinode.com)
